### PR TITLE
[ROO-91] memory leak ad-hoc fix

### DIFF
--- a/python/torch_mlir/extras/fx_importer.py
+++ b/python/torch_mlir/extras/fx_importer.py
@@ -2247,13 +2247,8 @@ class RefTracker:
         if existing:
             return existing
         info = RefMapping(referrent)
-        if referrent is not Empty:
-            weakref.finalize(referrent, self._ref_finalizer, ref_id)
         self._refs[ref_id] = info
         return info
-
-    def _ref_finalizer(self, ref_id: int):
-        del self._refs[ref_id]
 
 
 ################################################################################


### PR DESCRIPTION
### Ad-Hoc Bugfix against Memory Leak

The default current behaviour in the upstream keeps all (or a big portion) of the `torch.Tensor`s and `np.ndarray`s (that are kept as `memorview`s) in memory until the process is killed. An upstream issue is opened, a proper and more well-rounded solution will come at one point.

The source of the problem is the `ModuleBuilder` object attributes: `global_ref_tracker` and `fx_py_attr_tracker`, their class is imported from `iree.compile`. 

`RefTracker` class that is defined in `iree.compiler.extras.fx_importer` has these lines in it's `track` method:

```python
if referrent is not Empty:
            weakref.finalize(referrent, self._ref_finalizer, ref_id)
```
`referrent` corresponds to a `torch.Tensor` (or a `memoryview` of a `np.ndarray`) and this line causes it to be kept in memory until the process dies. Normally, the function passed into the `finalize` is called automatically, sort of as an additional finalization callback, when `referrent` is garbage collected. Unfortunately, if these lines are present, both the `weakref.finalize` objects and their corresponding tensors are not released. In the abscence of the above lines however, the tensors and the arrays are garbage collected automatically, except for the _last one_ that used the `aot.export` path, which can though be garbage collected with `gc.collect()` in the end.

The memory usage w/o the changes:

![image](https://github.com/user-attachments/assets/30b209c1-f533-4aa3-af5d-01fd95a8897b)


The memory usage w/ the changes:

![image](https://github.com/user-attachments/assets/a69aaf27-1d58-46d4-8ca9-cf45bb9ab020)

Last drop is with `gc.collect()` and drops the last pair of tensors and arrays.
